### PR TITLE
Updated

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,9 +16,9 @@ mkdir -p "$BUILD_DIR" "$TARGET_DIR"
 echo "#### FFmpeg static build, by STVS SA ####"
 cd $BUILD_DIR
 ../fetchurl "http://www.tortall.net/projects/yasm/releases/yasm-1.0.1.tar.gz"
-../fetchurl "http://zlib.net/zlib-1.2.5.tar.bz2"
+../fetchurl "http://zlib.net/zlib-1.2.6.tar.bz2"
 ../fetchurl "http://www.bzip.org/1.0.5/bzip2-1.0.5.tar.gz"
-../fetchurl "http://downloads.sourceforge.net/project/libpng/libpng12/1.2.46/libpng-1.2.46.tar.bz2"
+../fetchurl "http://download.sourceforge.net/libpng/libpng-1.2.47.tar.gz"
 ../fetchurl "http://downloads.xiph.org/releases/ogg/libogg-1.2.0.tar.gz"
 ../fetchurl "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.1.tar.bz2"
 ../fetchurl "http://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2"
@@ -35,7 +35,7 @@ cd "$BUILD_DIR/yasm-1.0.1"
 make -j 4 && make install
 
 echo "*** Building zlib ***"
-cd "$BUILD_DIR/zlib-1.2.5"
+cd "$BUILD_DIR/zlib-1.2.6"
 ./configure --prefix=$TARGET_DIR
 make -j 4 && make install
 
@@ -45,7 +45,7 @@ make
 make install PREFIX=$TARGET_DIR
 
 echo "*** Building libpng ***"
-cd "$BUILD_DIR/libpng-1.2.46"
+cd "$BUILD_DIR/libpng-1.2.47"
 ./configure --prefix=$TARGET_DIR --enable-static --disable-shared
 make -j 4 && make install
 
@@ -102,6 +102,7 @@ rm -f "$TARGET_DIR/lib/*.so"
 # FFMpeg
 echo "*** Building FFmpeg ***"
 cd "$BUILD_DIR/ffmpeg-0.6.1"
-./configure --prefix=${OUTPUT_DIR:-$TARGET_DIR} --extra-version=static --disable-debug --disable-shared --enable-static --extra-cflags=--static --disable-ffplay --disable-ffserver --disable-doc --enable-gpl --enable-pthreads --enable-postproc --enable-gray --enable-runtime-cpudetect --enable-libfaac --enable-libmp3lame --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libxvid --enable-bzlib --enable-zlib --enable-nonfree --enable-version3 --enable-libvpx --disable-devices
+patch -p1 <../../ffmpeg_config.patch
+CFLAGS="-I$TARGET_DIR/include" LDFLAGS="-L$TARGET_DIR/lib -lm" ./configure --prefix=${OUTPUT_DIR:-$TARGET_DIR} --extra-version=static --disable-debug --disable-shared --enable-static --extra-cflags=--static --disable-ffplay --disable-ffserver --disable-doc --enable-gpl --enable-pthreads --enable-postproc --enable-gray --enable-runtime-cpudetect --enable-libfaac --enable-libmp3lame --enable-libtheora --enable-libvorbis --enable-libx264 --enable-libxvid --enable-bzlib --enable-zlib --enable-nonfree --enable-version3 --enable-libvpx --disable-devices
 make -j 4 && make install
 

--- a/ffmpeg_config.patch
+++ b/ffmpeg_config.patch
@@ -1,0 +1,14 @@
+--- ffmpeg-0.6.1/configure      2010-06-15 21:44:30.000000000 +0200
++++ ffmpeg-static/build/ffmpeg-0.6.1/configure  2012-03-08 12:57:12.984471102 +0100
+@@ -629,7 +631,9 @@
+         test "${f}" = "${f#-l}" && flags="$flags $f" || libs="$libs $f"
+     done
+     check_cc $($filter_cflags $flags) || return
+-    check_cmd $ld $LDFLAGS $flags -o $TMPE $TMPO $extralibs $libs
++       extralibs=`echo "$extralibs" | sed s/-lm\s+//`
++       extralibs="$extralibs -lm"
++    check_cmd $ld $LDFLAGS $flags -o $TMPE $TMPO $libs $extralibs 
+ }
+ 
+ check_cppflags(){
+


### PR DESCRIPTION
- Bumped library versions because it was 404'ing
- ffmpeg/confiugre has been failing with "undefined reference to sqrt" and other mathematical functions when checking for faac. Added a patch to configure script which fixes this.
