### PR TITLE
Add pkg-config to apt-get install in build-ubuntu.sh

### DIFF
--- a/build-ubuntu.sh
+++ b/build-ubuntu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo apt-get install build-essential curl tar
+sudo apt-get install build-essential curl tar pkg-config
 
 ./build.sh


### PR DESCRIPTION
On some Ubuntu installations `pkg-config` is not available by default. This pull request adds `pkg-config` to `apt-get install` command to make sure it's there and doesn't fail with "opus not found" error.
