### PR TITLE
Fix mp3lame builds on aarch64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -127,7 +127,11 @@ make install
 
 echo "*** Building mp3lame ***"
 cd $BUILD_DIR/lame*
-./configure --prefix=$TARGET_DIR --enable-nasm --disable-shared
+if uname -a | grep -q 'aarch64'; then
+    # The lame build script does not recognize aarch64, so need to set it manually
+    lame_build_target="--build=arm-linux"
+fi
+./configure --prefix=$TARGET_DIR --enable-nasm --disable-shared $lame_build_target
 make
 make install
 


### PR DESCRIPTION
On aarch64, the mp3lame build was failing to identify the system architecture as below:

```
*** Building mp3lame ***
checking build system type... ./config.guess: unable to guess system type

This script, last modified 2003-07-02, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

    ftp://ftp.gnu.org/pub/gnu/config/

If the version you run (./config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2003-07-02

uname -m = aarch64
uname -r = 3.10.104-pine64
uname -s = Linux
uname -v = #2 SMP PREEMPT Thu Feb 23 22:26:21 CET 2017

/usr/bin/uname -p =
/bin/uname -X     =

hostinfo               =
/bin/universe          =
/usr/bin/arch -k       =
/bin/arch              =
/usr/bin/oslevel       =
/usr/convex/getsysinfo =

UNAME_MACHINE = aarch64
UNAME_RELEASE = 3.10.104-pine64
UNAME_SYSTEM  = Linux
UNAME_VERSION = #2 SMP PREEMPT Thu Feb 23 22:26:21 CET 2017
configure: error: cannot guess build type; you must specify one
```

Manually setting the target architecture by adding  `--build=arm-linux` to `./configure` fixes the problem.