### PR TITLE
Fix broken tar options on non-Debian based distributions.

### DIFF
--- a/fetchurl
+++ b/fetchurl
@@ -103,7 +103,7 @@ if [ "$UNPACK" -ne 0 ]; then
   mkdir -p "$target_dir"
   sh cd "$target_dir"
  
-  [ "$REPLACE" -ne 1 ] && tarargs="--keep-old-files --no-overwrite-dir" || tarargs=""
+  [ "$REPLACE" -ne 1 ] && tarargs="--skip-old-files" || tarargs=""
   case "$extname" in
     .tar.gz|.tgz)    
       sh tar "$tarargs" -xzvf "$cache_file"


### PR DESCRIPTION
It appears that `--no-overwrite-dir` cannot be used with `--keep-old-files`. On Debian, this is silently ignored, but it may cause the script to fail on other distributions. Switching to `--skip-old-files` should provide the intended behaviour: do not replace files if they already exist.

See http://lists.gnu.org/archive/html/bug-tar/2015-08/msg00004.html and https://lists.gnu.org/archive/html/bug-tar/2016-05/msg00015.html for reference.