### PR TITLE
Fix path variable set in wrong place for final ffmpeg build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -169,8 +169,8 @@ fi
 # FFMpeg
 echo "*** Building FFmpeg ***"
 cd $BUILD_DIR/FFmpeg*
-PATH="$BIN_DIR:$PATH" \
-[ $rebuild -eq 1 -o ! -f config.status ] && PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
+[ $rebuild -eq 1 -o ! -f config.status ] && PATH="$BIN_DIR:$PATH" \
+PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
   --prefix="$TARGET_DIR" \
   --pkg-config-flags="--static" \
   --extra-cflags="-I$TARGET_DIR/include" \


### PR DESCRIPTION
This was a derp accidentally introduced in `9e6527c`, which I missed because it doesn't impact ARM builds. Sorry!