### PR TITLE
Make an actual static build & allow building in docker & make it closer to Van Sickle's.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+bin/
+build/
+dl/
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:16.04
+
+# Basic packages needed to download dependencies and unpack them.
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  perl \
+  tar \
+  wget \
+  xz-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install packages necessary for compilation.
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  automake \
+  bash \
+  build-essential \
+  cmake \
+  curl \
+  libfontconfig-dev \
+  libfreetype6-dev \
+  libsdl1.2-dev \
+  libtheora-dev \
+  libtool \
+  libva-dev \
+  libvdpau-dev \
+  libvorbis-dev \
+  libxcb1-dev \
+  libxcb-shm0-dev \
+  libxcb-xfixes0-dev \
+  lsb-release \
+  pkg-config \
+  sudo \
+  tar \
+  texi2html \
+  yasm \
+  zlib1g-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy the build scripts.
+COPY build.sh download.pl env.source fetchurl /ffmpeg-static/
+
+VOLUME /ffmpeg-static
+CMD cd /ffmpeg-static; /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,26 @@ RUN apt-get update && apt-get install -y \
   build-essential \
   cmake \
   curl \
+  frei0r-plugins-dev \
+  gawk \
   libfontconfig-dev \
   libfreetype6-dev \
+  libopencore-amrnb-dev \
+  libopencore-amrwb-dev \
   libsdl1.2-dev \
+  libspeex-dev \
+  libssl-dev \
   libtheora-dev \
   libtool \
   libva-dev \
   libvdpau-dev \
+  libvo-amrwbenc-dev \
   libvorbis-dev \
+  libwebp-dev \
   libxcb1-dev \
   libxcb-shm0-dev \
   libxcb-xfixes0-dev \
+  libxvidcore-dev \
   lsb-release \
   pkg-config \
   sudo \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Build dependencies
 Build & "install"
 -----------------
 
-    $ ./build.sh [-j <jobs>] [-B]
+    $ ./build.sh [-j <jobs>] [-B] [-d]
     # ... wait ...
     # binaries can be found in ./target/bin/
 
@@ -30,12 +30,24 @@ Ubuntu users can download dependencies and and install in one command:
 
     $ sudo ./build-ubuntu.sh
 
-If you have built ffmpeg before with `build.sh`, the default behaviour is to keep the previous configuration. If you would like to reconfigure and rebuild all packages, use the `-B` flag. 
+If you have built ffmpeg before with `build.sh`, the default behaviour is to keep the previous configuration. If you would like to reconfigure and rebuild all packages, use the `-B` flag. `-d` flag will only download and unpack the dependencies but not build.
 
 NOTE: If you're going to use the h264 presets, make sure to copy them along the binaries. For ease, you can put them in your home folder like this:
 
     $ mkdir ~/.ffmpeg
     $ cp ./target/share/ffmpeg/*.ffpreset ~/.ffmpeg
+
+
+Build in docker
+---------------
+
+    $ docker build -t ffmpeg-static .
+    $ docker run -it ffmpeg-static
+    $ ./build.sh [-j <jobs>] [-B] [-d]
+
+The binaries will be created in `/ffmpeg-static/bin` directory.
+Method of getting them out of the Docker container is up to you.
+`/ffmpeg-static` is a Docker volume.
 
 Debug
 -----

--- a/build-ubuntu.sh
+++ b/build-ubuntu.sh
@@ -25,7 +25,7 @@ sudo apt-get -y --force-yes install \
 # libx265 requires cmake version >= 2.8.8
 # 12.04 only have 2.8.7
 ubuntu_version=`lsb_release -rs`
-need_ppa=`echo $ubuntu_version'<=12.04' | bc -l)`
+need_ppa=`echo $ubuntu_version'<=12.04' | bc -l`
 if [ $need_ppa -eq 1 ]; then
     sudo add-apt-repository ppa:roblib/ppa
     sudo apt-get update

--- a/build-ubuntu.sh
+++ b/build-ubuntu.sh
@@ -6,17 +6,26 @@ sudo apt-get -y --force-yes install \
   automake \
   build-essential \
   cmake \
+  frei0r-plugins-dev \
+  gawk \
   libass-dev \
   libfreetype6-dev \
+  libopencore-amrnb-dev \
+  libopencore-amrwb-dev \
   libsdl1.2-dev \
+  libspeex-dev \
+  libssl-dev \
   libtheora-dev \
   libtool \
   libva-dev \
   libvdpau-dev \
+  libvo-amrwbenc-dev \
   libvorbis-dev \
+  libwebp-dev \
   libxcb1-dev \
   libxcb-shm0-dev \
   libxcb-xfixes0-dev \
+  libxvidcore-dev \
   pkg-config \
   texi2html \
   zlib1g-dev

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,25 @@ download \
   "nil" \
   "https://github.com/mstorsjo/fdk-aac/tarball"
 
+# libass dependency
+download \
+  "harfbuzz-1.4.6.tar.bz2" \
+  "" \
+  "e246c08a3bac98e31e731b2a1bf97edf" \
+  "https://www.freedesktop.org/software/harfbuzz/release/"
+
+download \
+  "fribidi-0.19.7.tar.bz2" \
+  "" \
+  "6c7e7cfdd39c908f7ac619351c1c5c23" \
+  "https://www.fribidi.org/download/"
+
+download \
+  "0.13.6.tar.gz" \
+  "libass-0.13.6.tar.gz" \
+  "nil" \
+  "https://github.com/libass/libass/archive/"
+
 download \
   "lame-3.99.5.tar.gz" \
   "" \
@@ -141,6 +160,28 @@ autoreconf -fiv
 make -j $jval
 make install
 
+echo "*** Building harfbuzz ***"
+cd $BUILD_DIR/harfbuzz-*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./configure --prefix=$TARGET_DIR --disable-shared --enable-static
+make -j $jval
+make install
+
+echo "*** Building fribidi ***"
+cd $BUILD_DIR/fribidi-*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./configure --prefix=$TARGET_DIR --disable-shared --enable-static
+make -j $jval
+make install
+
+echo "*** Building libass ***"
+cd $BUILD_DIR/libass-*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./autogen.sh
+./configure --prefix=$TARGET_DIR --disable-shared
+make -j $jval
+make install
+
 echo "*** Building mp3lame ***"
 cd $BUILD_DIR/lame*
 # The lame build script does not recognize aarch64, so need to set it manually
@@ -181,12 +222,14 @@ PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
   --pkg-config-flags="--static" \
   --extra-cflags="-I$TARGET_DIR/include" \
   --extra-ldflags="-L$TARGET_DIR/lib" \
+  --extra-ldexeflags="-static" \
   --bindir="$BIN_DIR" \
   --enable-pic \
   --enable-ffplay \
   --enable-ffserver \
   --enable-gpl \
   --enable-libass \
+  --enable-libfribidi \
   --enable-libfdk-aac \
   --enable-libfreetype \
   --enable-libmp3lame \

--- a/build.sh
+++ b/build.sh
@@ -127,12 +127,44 @@ download \
   "https://github.com/webmproject/libvpx/archive"
 
 download \
+  "rtmpdump-2.3.tgz" \
+  "" \
+  "eb961f31cd55f0acf5aad1a7b900ef59" \
+  "https://rtmpdump.mplayerhq.hu/download/"
+
+download \
+  "soxr-0.1.2-Source.tar.xz" \
+  "" \
+  "0866fc4320e26f47152798ac000de1c0" \
+  "https://sourceforge.net/projects/soxr/files/"
+
+download \
+  "release-0.98b.tar.gz" \
+  "vid.stab-release-0.98b.tar.gz" \
+  "299b2f4ccd1b94c274f6d94ed4f1c5b8" \
+  "https://github.com/georgmartius/vid.stab/archive/"
+
+download \
+  "release-2.5.1.tar.gz" \
+  "zimg-release-2.5.1.tar.gz" \
+  "24afac41d38398bef9ee9a55c6bf1627" \
+  "https://github.com/sekrit-twc/zimg/archive/"
+
+download \
+  "v2.1.2.tar.gz" \
+  "openjpeg-2.1.2.tar.gz" \
+  "40a7bfdcc66280b3c1402a0eb1a27624" \
+  "https://github.com/uclouvain/openjpeg/archive/"
+
+download \
   "n3.2.4.tar.gz" \
   "ffmpeg3.2.4.tar.gz" \
   "8ca58121dd042153656d89eba3daa7ab" \
   "https://github.com/FFmpeg/FFmpeg/archive"
 
 [ $download_only -eq 1 ] && exit 0
+
+TARGET_DIR_SED=$(echo $TARGET_DIR | awk '{gsub(/\//, "\\/"); print}')
 
 if [ $is_x86 -eq 1 ]; then
     echo "*** Building yasm ***"
@@ -211,6 +243,44 @@ cd $BUILD_DIR/libvpx*
 PATH="$BIN_DIR:$PATH" make -j $jval
 make install
 
+echo "*** Building librtmp ***"
+cd $BUILD_DIR/rtmpdump-*
+cd librtmp
+[ $rebuild -eq 1 ] && make distclean || true
+sed -i "s/prefix=.*/prefix=${TARGET_DIR_SED}/" ./Makefile # there's no configure
+make -j $jval
+make install
+
+echo "*** Building libsoxr ***"
+cd $BUILD_DIR/soxr-*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+PATH="$BIN_DIR:$PATH" cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="$TARGET_DIR" -DBUILD_SHARED_LIBS:bool=off -DWITH_OPENMP:bool=off -DBUILD_TESTS:bool=off
+make -j $jval
+make install
+
+echo "*** Building libvidstab ***"
+cd $BUILD_DIR/vid.stab-release-*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+sed -i "s/vidstab SHARED/vidstab STATIC/" ./CMakeLists.txt
+PATH="$BIN_DIR:$PATH" cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="$TARGET_DIR"
+make -j $jval
+make install
+
+echo "*** Building openjpeg ***"
+cd $BUILD_DIR/openjpeg-*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+PATH="$BIN_DIR:$PATH" cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="$TARGET_DIR" -DBUILD_SHARED_LIBS:bool=off
+make -j $jval
+make install
+
+echo "*** Building zimg ***"
+cd $BUILD_DIR/zimg-release-*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./autogen.sh
+./configure --enable-static  --prefix=$TARGET_DIR --disable-shared
+make -j $jval
+make install
+
 NPROC=1
 if which `nproc`;then
 	NPROC="`nproc`"
@@ -233,18 +303,32 @@ PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
   --enable-pic \
   --enable-ffplay \
   --enable-ffserver \
+  --enable-fontconfig \
+  --enable-frei0r \
   --enable-gpl \
+  --enable-version3 \
   --enable-libass \
   --enable-libfribidi \
   --enable-libfdk-aac \
   --enable-libfreetype \
   --enable-libmp3lame \
+  --enable-libopencore-amrnb \
+  --enable-libopencore-amrwb \
+  --enable-libopenjpeg \
   --enable-libopus \
+  --enable-librtmp \
+  --enable-libsoxr \
+  --enable-libspeex \
   --enable-libtheora \
+  --enable-libvidstab \
+  --enable-libvo-amrwbenc \
   --enable-libvorbis \
   --enable-libvpx \
+  --enable-libwebp \
   --enable-libx264 \
   --enable-libx265 \
+  --enable-libxvid \
+  --enable-libzimg \
   --enable-nonfree
 PATH="$BIN_DIR:$PATH" make -j$NPROC
 make install

--- a/build.sh
+++ b/build.sh
@@ -281,13 +281,6 @@ cd $BUILD_DIR/zimg-release-*
 make -j $jval
 make install
 
-NPROC=1
-if which `nproc`;then
-	NPROC="`nproc`"
-elif [ -f /proc/cpuinfo ];then
-	NPROC="`grep -c ^processor /proc/cpuinfo`"
-fi
-
 # FFMpeg
 echo "*** Building FFmpeg ***"
 cd $BUILD_DIR/FFmpeg*
@@ -330,7 +323,7 @@ PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
   --enable-libxvid \
   --enable-libzimg \
   --enable-nonfree
-PATH="$BIN_DIR:$PATH" make -j$NPROC
+PATH="$BIN_DIR:$PATH" make -j $jval
 make install
 make distclean
 hash -r

--- a/build.sh
+++ b/build.sh
@@ -6,9 +6,10 @@ set -u
 jflag=
 jval=2
 rebuild=0
+download_only=0
 uname -mpi | grep -qE 'x86|i386|i686' && is_x86=1 || is_x86=0
 
-while getopts 'j:B' OPTION
+while getopts 'j:Bd' OPTION
 do
   case $OPTION in
   j)
@@ -18,8 +19,11 @@ do
   B)
       rebuild=1
       ;;
+  d)
+      download_only=1
+      ;;
   ?)
-      printf "Usage: %s: [-j concurrency_level] (hint: your cores + 20%%) [-B]\n" $(basename $0) >&2
+      printf "Usage: %s: [-j concurrency_level] (hint: your cores + 20%%) [-B] [-d]\n" $(basename $0) >&2
       exit 2
       ;;
   esac
@@ -127,6 +131,8 @@ download \
   "ffmpeg3.2.4.tar.gz" \
   "8ca58121dd042153656d89eba3daa7ab" \
   "https://github.com/FFmpeg/FFmpeg/archive"
+
+[ $download_only -eq 1 ] && exit 0
 
 if [ $is_x86 -eq 1 ]; then
     echo "*** Building yasm ***"

--- a/fetchurl
+++ b/fetchurl
@@ -94,6 +94,8 @@ if [ "$UNPACK" -ne 0 ]; then
     extname=.tgz
   elif [ "$filename" != "${filename%.tar.bz2}" ]; then
     extname=.tar.bz2
+  elif [ "$filename" != "${filename%.tar.xz}" ]; then
+    extname=.tar.xz
   else
     stderr extension of $filename is not supported
     exit 1
@@ -110,6 +112,9 @@ if [ "$UNPACK" -ne 0 ]; then
     ;;
     .tar.bz2)
       sh tar "$tarargs" -xjvf "$cache_file"
+    ;;
+    .tar.xz)
+      sh tar "$tarargs" -xJvf "$cache_file"
     ;;
     *)
       stderr BUG, this should not happen


### PR DESCRIPTION
Commit messages should speak for themselves. The short summary of this PR is to make it easier to build independently of your OS (thanks to Docker) and to make the build itself closer to what is produced by John Van Sickle. I still had problems with --enable-gnutls, where linker died on duplicated functions, and with --enable-libmfx, as it seems it's some obscure Intel stuff. There are also 2 commits that purely fix bugs: the $jval being ignored for the ffmpeg build itself, and a stray ")" breaking build-ubuntu.sh.