### PR TITLE
SSL: Enable the use of OpenSSL for protocols

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -337,7 +337,8 @@ PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
   --enable-libx265 \
   --enable-libxvid \
   --enable-libzimg \
-  --enable-nonfree
+  --enable-nonfree \
+  --enable-openssl
 PATH="$BIN_DIR:$PATH" make -j $jval
 make install
 make distclean


### PR DESCRIPTION
Currently the base image is including libssl-dev and portions of the
OpenSSL codebase are used for rtmpe & rtmpte support.

This would allow the use of the following protocols for both input and output:
  - https://
  - tls://

Affects #64