### PR TITLE
Add --enable-post-proc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -338,7 +338,8 @@ PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
   --enable-libxvid \
   --enable-libzimg \
   --enable-nonfree \
-  --enable-openssl
+  --enable-openssl \
+  --enable-post-proc 
 PATH="$BIN_DIR:$PATH" make -j $jval
 make install
 make distclean


### PR DESCRIPTION
Adds `--enable-post-proc` to `./configure` build to work better with GPL post processing. Useful in projects such as bbb-download for BigBlueButton.
https://github.com/alpapado/bbb-download