### PR TITLE
[darwin]: MacOS compatible build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:17.10
 
 # Basic packages needed to download dependencies and unpack them.
 RUN apt-get update && apt-get install -y \
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
   libfreetype6-dev \
   libopencore-amrnb-dev \
   libopencore-amrwb-dev \
-  libsdl1.2-dev \
+  libsdl2-dev \
   libspeex-dev \
   libssl-dev \
   libtheora-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:bionic
 
 # Basic packages needed to download dependencies and unpack them.
 RUN apt-get update && apt-get install -y \
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y \
   libopencore-amrwb-dev \
   libsdl2-dev \
   libspeex-dev \
-  libssl-dev \
   libtheora-dev \
   libtool \
   libva-dev \
@@ -43,7 +42,6 @@ RUN apt-get update && apt-get install -y \
   tar \
   texi2html \
   yasm \
-  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy the build scripts.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Build dependencies
     # 1. install XCode
     # 2. install XCode command line tools
     # 3. install homebrew
-    # brew install openssl frei0r
+    # brew install openssl frei0r sdl2
 
 Build & "install"
 -----------------

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Build dependencies
     $ apt-get install build-essential curl tar libass-dev libtheora-dev libvorbis-dev libtool cmake automake autoconf
 
     # OS X
-    # install XCode, it can be found at http://developer.apple.com/
-    # (apple login needed)
-    # <FIXME???>
+    # 1. install XCode
+    # 2. install XCode command line tools
+    # 3. install homebrew
+    # brew install openssl frei0r
 
 Build & "install"
 -----------------
@@ -55,7 +56,7 @@ Debug
 On the top-level of the project, run:
 
     $ . env.source
-    
+
 You can then enter the source folders and make the compilation yourself
 
     $ cd build/ffmpeg-*
@@ -69,11 +70,11 @@ I'm not sure it's a good idea to statically link those, but it probably
 means the executable won't work across distributions or even across releases.
 
     # On Ubuntu 10.04:
-    $ ldd ./target/bin/ffmpeg 
+    $ ldd ./target/bin/ffmpeg
     not a dynamic executable
 
     # on OSX 10.6.4:
-    $ otool -L ffmpeg 
+    $ otool -L ffmpeg
     ffmpeg:
         /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 125.2.0)
 
@@ -88,7 +89,7 @@ As a contributor you can do whatever you want. Help maintain the scripts,
 upgrade dependencies and merge other people's PRs. Just be responsible and
 make an issue if you want to introduce bigger changes so we can discuss them
 beforehand.
- 
+
 ### TODO
 
  * Add some tests to check that video output is correctly generated

--- a/build.sh
+++ b/build.sh
@@ -164,9 +164,9 @@ download \
   "https://github.com/georgmartius/vid.stab/archive/"
 
 download \
-  "release-2.5.1.tar.gz" \
-  "zimg-release-2.5.1.tar.gz" \
-  "24afac41d38398bef9ee9a55c6bf1627" \
+  "release-2.7.4.tar.gz" \
+  "zimg-release-2.7.4.tar.gz" \
+  "1757dcc11590ef3b5a56c701fd286345" \
   "https://github.com/sekrit-twc/zimg/archive/"
 
 download \
@@ -176,9 +176,33 @@ download \
   "https://github.com/uclouvain/openjpeg/archive/"
 
 download \
-  "n3.4.2.tar.gz" \
-  "ffmpeg3.4.2.tar.gz" \
-  "935a1c02531f6e2b8c97d35cef4e4538" \
+  "v0.6.1.tar.gz" \
+  "libwebp-0.6.1.tar.gz" \
+  "1c3099cd2656d0d80d3550ee29fc0f28" \
+  "https://github.com/webmproject/libwebp/archive/"
+
+download \
+  "v1.3.6.tar.gz" \
+  "vorbis-1.3.6.tar.gz" \
+  "03e967efb961f65a313459c5d0f4cbfb" \
+  "https://github.com/xiph/vorbis/archive/"
+
+download \
+  "v1.3.3.tar.gz" \
+  "ogg-1.3.3.tar.gz" \
+  "b8da1fe5ed84964834d40855ba7b93c2" \
+  "https://github.com/xiph/ogg/archive/"
+
+download \
+  "Speex-1.2.0.tar.gz" \
+  "Speex-1.2.0.tar.gz" \
+  "4bec86331abef56129f9d1c994823f03" \
+  "https://github.com/xiph/speex/archive/"
+
+download \
+  "n4.0.tar.gz" \
+  "ffmpeg4.0.tar.gz" \
+  "4749a5e56f31e7ccebd3f9924972220f" \
   "https://github.com/FFmpeg/FFmpeg/archive"
 
 [ $download_only -eq 1 ] && exit 0
@@ -318,6 +342,38 @@ cd $BUILD_DIR/zimg-release-*
 make -j $jval
 make install
 
+echo "*** Building libwebp ***"
+cd $BUILD_DIR/libwebp*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./autogen.sh
+./configure --prefix=$TARGET_DIR --disable-shared
+make -j $jval
+make install
+
+echo "*** Building libvorbis ***"
+cd $BUILD_DIR/vorbis*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./autogen.sh
+./configure --prefix=$TARGET_DIR --disable-shared
+make -j $jval
+make install
+
+echo "*** Building libogg ***"
+cd $BUILD_DIR/ogg*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./autogen.sh
+./configure --prefix=$TARGET_DIR --disable-shared
+make -j $jval
+make install
+
+echo "*** Building libspeex ***"
+cd $BUILD_DIR/speex*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+./autogen.sh
+./configure --prefix=$TARGET_DIR --disable-shared
+make -j $jval
+make install
+
 # FFMpeg
 echo "*** Building FFmpeg ***"
 cd $BUILD_DIR/FFmpeg*
@@ -334,7 +390,6 @@ if [ "$platform" = "linux" ]; then
     --bindir="$BIN_DIR" \
     --enable-pic \
     --enable-ffplay \
-    --enable-ffserver \
     --enable-fontconfig \
     --enable-frei0r \
     --enable-gpl \
@@ -375,7 +430,6 @@ elif [ "$platform" = "darwin" ]; then
     --bindir="$BIN_DIR" \
     --enable-pic \
     --enable-ffplay \
-    --enable-ffserver \
     --enable-fontconfig \
     --enable-frei0r \
     --enable-gpl \

--- a/build.sh
+++ b/build.sh
@@ -275,11 +275,11 @@ echo "*** Building librtmp ***"
 cd $BUILD_DIR/rtmpdump-*
 cd librtmp
 [ $rebuild -eq 1 ] && make distclean || true
-if [[ "$platform" == "linux" ]]; then
+if [ "$platform" = "linux" ]; then
   sed -i "s/prefix=.*/prefix=${TARGET_DIR_SED}/" ./Makefile # there's no configure
   make -j $jval
   make install
-elif [[ "$platform" == "darwin" ]]; then
+elif [ "$platform" = "darwin" ]; then
   sed -i "" "s/prefix=.*/prefix=${TARGET_DIR_SED}/" ./Makefile # there's no configure
   make install_base
 fi
@@ -294,9 +294,9 @@ make install
 echo "*** Building libvidstab ***"
 cd $BUILD_DIR/vid.stab-release-*
 [ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
-if [[ "$platform" == "linux" ]]; then
+if [ "$platform" = "linux" ]; then
   sed -i "s/vidstab SHARED/vidstab STATIC/" ./CMakeLists.txt
-elif [[ "$platform" == "darwin" ]]; then
+elif [ "$platform" = "darwin" ]; then
   sed -i "" "s/vidstab SHARED/vidstab STATIC/" ./CMakeLists.txt
 fi
 PATH="$BIN_DIR:$PATH" cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX="$TARGET_DIR"
@@ -322,15 +322,15 @@ make install
 echo "*** Building FFmpeg ***"
 cd $BUILD_DIR/FFmpeg*
 [ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
-[ ! -f config.status ] && PATH="$BIN_DIR:$PATH" \
 
-if [[ "$platform" == "linux" ]]; then
+if [ "$platform" = "linux" ]; then
+  [ ! -f config.status ] && PATH="$BIN_DIR:$PATH" \
   PKG_CONFIG_PATH="$TARGET_DIR/lib/pkgconfig" ./configure \
     --prefix="$TARGET_DIR" \
     --pkg-config-flags="--static" \
     --extra-cflags="-I$TARGET_DIR/include" \
     --extra-ldflags="-L$TARGET_DIR/lib" \
-    --extra-ldexeflags="-static" \
+    --extra-ldexeflags="-Bstatic" \
     --bindir="$BIN_DIR" \
     --enable-pic \
     --enable-ffplay \
@@ -363,7 +363,8 @@ if [[ "$platform" == "linux" ]]; then
     --enable-libzimg \
     --enable-nonfree \
     --enable-openssl
-elif [[ "$platform" == "darwin" ]]; then
+elif [ "$platform" = "darwin" ]; then
+  [ ! -f config.status ] && PATH="$BIN_DIR:$PATH" \
   PKG_CONFIG_PATH="${TARGET_DIR}/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/local/Cellar/openssl/1.0.2o_1/lib/pkgconfig" ./configure \
     --cc=/usr/bin/clang \
     --prefix="$TARGET_DIR" \

--- a/fetchurl
+++ b/fetchurl
@@ -105,7 +105,7 @@ if [ "$UNPACK" -ne 0 ]; then
   mkdir -p "$target_dir"
   sh cd "$target_dir"
 
-  [ "$REPLACE" -ne 1 ] && tarargs=""
+  [ "$REPLACE" -ne 1 ] && [ `uname` = "Linux" ] && tarargs="--keep-old-files" || tarargs=""
   case "$extname" in
     .tar.gz|.tgz)
       sh tar "$tarargs" -xzvf "$cache_file"

--- a/fetchurl
+++ b/fetchurl
@@ -104,10 +104,10 @@ if [ "$UNPACK" -ne 0 ]; then
   target_dir=`expand_path "$EXTRACT_DIR"`
   mkdir -p "$target_dir"
   sh cd "$target_dir"
- 
-  [ "$REPLACE" -ne 1 ] && tarargs="--skip-old-files" || tarargs=""
+
+  [ "$REPLACE" -ne 1 ] && tarargs=""
   case "$extname" in
-    .tar.gz|.tgz)    
+    .tar.gz|.tgz)
       sh tar "$tarargs" -xzvf "$cache_file"
     ;;
     .tar.bz2)


### PR DESCRIPTION
This PR adds compatibility to build static FFmpeg builds right off running `./build.sh` script and in same time doesn't affect Linux builds. 

I also updated FFmpeg version to `4.0` and make build a bit more static with adding additional libraries to be built statically.