### PR TITLE
'tar --keep-old-files' causes exit code 2, revert back to '--skip-old…

### DIFF
--- a/fetchurl
+++ b/fetchurl
@@ -105,7 +105,7 @@ if [ "$UNPACK" -ne 0 ]; then
   mkdir -p "$target_dir"
   sh cd "$target_dir"
 
-  [ "$REPLACE" -ne 1 ] && [ `uname` = "Linux" ] && tarargs="--keep-old-files" || tarargs=""
+  [ "$REPLACE" -ne 1 ] && [ `uname` = "Linux" ] && tarargs="--skip-old-files" || tarargs=""
   case "$extname" in
     .tar.gz|.tgz)
       sh tar "$tarargs" -xzvf "$cache_file"


### PR DESCRIPTION
…-files'

Because of '-keep-old-files', build.sh could only be run once.
Subsequent runs would stop on trying to extract the first download.