### PR TITLE
Make ffmpeg static again and fix Linux build in general.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+install:
+  - docker build -t ci .
+
+script:
+  - docker run -ti --rm ci bash -c "cd /ffmpeg-static ; ./build.sh -j $(($(nproc) + 1)) && ldd bin/ffmpeg ; (ldd bin/ffmpeg | grep 'not a dynamic executable')"


### PR DESCRIPTION
* Use $TARGET_DIR, not /usr/local, as prefix in Linux builds
  of OpenSSL and zlib. This problem was not affecting Docker
  builds because you have root rights there, but building
  outside Docker was no longer possible.

* ffmpeg --extra-ldexeflags '-static' is vital in getting an actually
  static build. '-Bstatic' is for something else and was useless
  in this context.

* librtmp now needs to include openssl/ssl.h from
  $TARGET_DIR/include path. "INC=" entry is added to
  the Makefile.

* Disable x265 CLI target because it is not needed.

* x265.pc: -lgcc_s must be replaced with -lgcc_eh.
  Unfortunately, due to how x265 CMakeLists.txt is constructed,
  this cannot be done in any other way than just replacing it
  with 'sed' after the file has been already created.