### PR TITLE
Fix issues on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Build dependencies
     # 1. install XCode
     # 2. install XCode command line tools
     # 3. install homebrew
-    # brew install openssl frei0r sdl2
+    # brew install cmake automake openssl frei0r sdl2
 
 Build & "install"
 -----------------


### PR DESCRIPTION
- In BSD sed, -i needs a suffix. As a fix, pass -i="", which also works with GNU sed.
- BSD sed does not support the \n escape sequence in replacements. Use perl instead.