### PR TITLE
Add SRT/RIST and update to FFMpeg 6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,6 +103,12 @@ download \
   "https://github.com/madler/zlib/archive/"
 
 download \
+  "v1.5.3.tar.gz" \
+  "" \
+  "df8213a3669dd846ddaad0fa1e9f417b" \
+  "https://github.com/Haivision/srt/archive/refs/tags/"
+
+download \
   "x264-stable.tar.gz" \
   "" \
   "nil" \
@@ -212,9 +218,9 @@ download \
   "https://github.com/xiph/speex/archive/"
 
 download \
-  "n4.0.tar.gz" \
-  "ffmpeg4.0.tar.gz" \
-  "4749a5e56f31e7ccebd3f9924972220f" \
+  "n6.0.tar.gz" \
+  "ffmpeg6.0.tar.gz" \
+  "586ca7cc091d26fd0a4c26308950ca51" \
   "https://github.com/FFmpeg/FFmpeg/archive"
 
 download \
@@ -426,6 +432,30 @@ cd $BUILD_DIR/SDL*
 make -j $jval
 make install
 
+echo "*** Building RIST ***"
+cd $BUILD_DIR
+rm -rf librist
+git clone https://code.videolan.org/rist/librist.git
+cd $BUILD_DIR/librist*
+git checkout v0.2.10
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+mkdir -p build
+cd build
+meson --default-library=static .. --prefix=$TARGET_DIR --bindir="../bin/" --libdir="$TARGET_DIR/lib"
+ninja
+ninja install
+
+echo "*** Building SRT ***"
+cd $BUILD_DIR/srt*
+[ $rebuild -eq 1 -a -f Makefile ] && make distclean || true
+mkdir -p build
+cd build
+cmake -DENABLE_APPS=OFF -DCMAKE_INSTALL_PREFIX=$TARGET_DIR -DENABLE_C_DEPS=ON -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DOPENSSL_USE_STATIC_LIBS=ON ..
+sed -i 's/-lgcc_s/-lgcc_eh/g' haisrt.pc
+sed -i 's/-lgcc_s/-lgcc_eh/g' srt.pc
+make
+make install
+
 # FFMpeg
 echo "*** Building FFmpeg ***"
 cd $BUILD_DIR/FFmpeg*
@@ -470,7 +500,9 @@ if [ "$platform" = "linux" ]; then
     --enable-libxvid \
     --enable-libzimg \
     --enable-nonfree \
-    --enable-openssl
+    --enable-openssl \
+    --enable-librist \
+    --enable-libsrt
 elif [ "$platform" = "darwin" ]; then
   [ ! -f config.status ] && PATH="$BIN_DIR:$PATH" \
   PKG_CONFIG_PATH="${TARGET_DIR}/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/local/Cellar/openssl/1.0.2o_1/lib/pkgconfig" ./configure \
@@ -508,7 +540,9 @@ elif [ "$platform" = "darwin" ]; then
     --enable-libxvid \
     --enable-libzimg \
     --enable-nonfree \
-    --enable-openssl
+    --enable-openssl \
+    --enable-librist \
+    --enable-libsrt
 fi
 
 PATH="$BIN_DIR:$PATH" make -j $jval


### PR DESCRIPTION
- Add SRT version 1.5.3 (latest to date)
- Add RIST version 0.2.10 (latest to date)
- Update FFMpeg to 6.0

I tested and compiled with this additions and the 3 binaries (ffmpeg, ffplay, ffprobe) still were static, but just in case, test it to be sure.