### PR TITLE
Fix docker build / bump FFmpeg to 7.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:noble
 # Basic packages needed to download dependencies and unpack them.
 RUN apt-get update && apt-get install -y \
   bzip2 \
+  git \
   perl \
   tar \
   wget \
@@ -37,6 +38,7 @@ RUN apt-get update && apt-get install -y \
   libxcb-xfixes0-dev \
   libxvidcore-dev \
   lsb-release \
+  meson \
   pkg-config \
   sudo \
   tar \

--- a/build.sh
+++ b/build.sh
@@ -218,9 +218,9 @@ download \
   "https://github.com/xiph/speex/archive/"
 
 download \
-  "n6.0.tar.gz" \
-  "ffmpeg6.0.tar.gz" \
-  "586ca7cc091d26fd0a4c26308950ca51" \
+  "n7.0.1.tar.gz" \
+  "ffmpeg7.0.1.tar.gz" \
+  "ad3a6a42520c4a9b42498dea28ec7f44" \
   "https://github.com/FFmpeg/FFmpeg/archive"
 
 download \


### PR DESCRIPTION
Fixes the docker build which broke when upgrading to Ubuntu 24.04 as meson and git needed to be added.

Also bumps FFmpeg to 7.0.1. Verified working locally.